### PR TITLE
hotfix/fixing bigint

### DIFF
--- a/app/Http/Controllers/API/CollectionPointController.php
+++ b/app/Http/Controllers/API/CollectionPointController.php
@@ -113,7 +113,7 @@ class CollectionPointController extends Controller
         ]);
     }
 
-    public function getMeals($id) {
+    public function getMeals(int $id) {
         $meals = Meal::with("tags")->where("collection_point_id", $id)->get();
 
         if($meals->isEmpty()) {


### PR DESCRIPTION
> SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type bigint: ":id" (SQL: select * from "meals" where "collection_point_id" = :id)